### PR TITLE
增加了技能类，修改了元素相克的逻辑

### DIFF
--- a/genshin/Classes/Common/Element/Element.cpp
+++ b/genshin/Classes/Common/Element/Element.cpp
@@ -37,26 +37,33 @@ bool operator!=(Element lhs, Element rhs) {
 }
 
 float calculateElementalDamageModifier(Element attackerElement, Element targetElement) {
-    // 属性相克关系
-    if (attackerElement == Element::FIRE && targetElement == Element::EARTH ||
-        attackerElement == Element::WATER && targetElement == Element::FIRE ||
-        attackerElement == Element::EARTH && targetElement == Element::AIR ||
-        attackerElement == Element::AIR && targetElement == Element::WATER ||
-        ) {
-        return 1.2f;  // 火克土\水克火\土克风\风克水
+    // 属性克制关系
+    if ((attackerElement == Element::FIRE && targetElement == Element::GRASS) ||
+        (attackerElement == Element::WATER && targetElement == Element::FIRE) ||
+        (attackerElement == Element::EARTH && targetElement == Element::THUNDER) ||
+        (attackerElement == Element::AIR && targetElement == Element::ICE) ||
+        (attackerElement == Element::THUNDER && targetElement == Element::WATER) ||
+        (attackerElement == Element::GRASS && targetElement == Element::EARTH) ||
+        (attackerElement == Element::ICE && targetElement == Element::THUNDER)) {
+        return 1.2f;  // 克制，伤害提升
     }
+
+    // 属性被克制关系
+    if ((attackerElement == Element::FIRE && targetElement == Element::WATER) ||
+        (attackerElement == Element::WATER && targetElement == Element::THUNDER) ||
+        (attackerElement == Element::EARTH && targetElement == Element::GRASS) ||
+        (attackerElement == Element::AIR && targetElement == Element::EARTH) ||
+        (attackerElement == Element::THUNDER && targetElement == Element::ICE) ||
+        (attackerElement == Element::GRASS && targetElement == Element::FIRE) ||
+        (attackerElement == Element::ICE && targetElement == Element::AIR)) {
+        return 0.8f;  // 被克制，伤害降低
+    }
+
+    // 属性相同
     if (attackerElement == targetElement) {
         return 1.0f;  // 元素相同，正常伤害
     }
 
-    // 被克制的情况
-    if ((attackerElement == Element::FIRE && targetElement == Element::WATER) ||
-        (attackerElement == Element::WATER && targetElement == Element::EARTH) ||
-        (attackerElement == Element::EARTH && targetElement == Element::AIR) ||
-        (attackerElement == Element::AIR && targetElement == Element::FIRE)) {
-        return 0.8f;  // 被克制，伤害减少
-    }
-
-    return 1.0f;  // 默认返回 1，表示没有元素相克
+    return 1.0f;  // 默认返回正常伤害
 }
 

--- a/genshin/Classes/Common/Entities/Player/Player.cpp
+++ b/genshin/Classes/Common/Entities/Player/Player.cpp
@@ -2,17 +2,25 @@
 #include "cocos2d.h"
 
 Player::Player(float health, Element element)
-    : Entities(health, element), experience(0), level(1), weapon(nullptr), armor(nullptr), accessory(nullptr) {}
+    : Entities(health, element), experience(0), level(1), weapon(nullptr), armor(nullptr), accessory(nullptr), activeShield(0) {
+    skillBar.resize(3, nullptr); // 初始化技能栏为空
+}
 
 
-Player::Player() : Entities(100, Element::WATER), experience(0), level(1), weapon(nullptr), armor(nullptr), accessory(nullptr) {}
-
+Player::Player() : Entities(100, Element::WATER), experience(0), level(1), weapon(nullptr), armor(nullptr), accessory(nullptr), activeShield(0) {
+    skillBar.resize(3, nullptr); // 初始化技能栏为空
+}
 
 void Player::levelUp() {
     level++;
     maxHealth += 20.0f;  // 每次升级增加最大血量
     health = maxHealth;   // 血量恢复
     CCLOG("Level up! Now level %d", level);
+
+    // 解锁新技能
+    if (level == 2) unlockSkill(std::make_shared<FireballSkill>());
+    if (level == 3) unlockSkill(std::make_shared<ShieldSkill>());
+    if (level == 4) unlockSkill(std::make_shared<HealSkill>());
 }
 
 int Player::getLevel() const {
@@ -107,4 +115,108 @@ Armor* Player::getArmor() const {
 
 Accessory* Player::getAccessory() const {
     return accessory;
+}
+
+void Player::unlockSkill(const std::shared_ptr<Skill>& newSkill) {
+    unlockedSkills.push_back(newSkill);
+    CCLOG("Unlocked skill: %s", newSkill->getName().c_str());
+}
+
+bool Player::equipSkill(int skillSlot, const std::shared_ptr<Skill>& skill) {
+    if (skillSlot < 0 || skillSlot >= 3) {
+        CCLOG("Invalid skill slot: %d", skillSlot);
+        return false;
+    }
+
+    if (std::find(skillBar.begin(), skillBar.end(), skill) != skillBar.end()) {
+        CCLOG("Skill %s is already equipped.", skill->getName().c_str());
+        return false; // 不能重复装备
+    }
+
+    skillBar[skillSlot] = skill;
+    CCLOG("Equipped skill: %s in slot %d", skill->getName().c_str(), skillSlot);
+    return true;
+}
+
+void Player::unequipSkill(int skillSlot) {
+    if (skillSlot < 0 || skillSlot >= 3 || !skillBar[skillSlot]) {
+        CCLOG("Invalid or empty skill slot: %d", skillSlot);
+        return;
+    }
+
+    CCLOG("Unequipped skill: %s from slot %d", skillBar[skillSlot]->getName().c_str(), skillSlot);
+    skillBar[skillSlot] = nullptr;
+}
+
+void Player::useSkill(int skillSlot, Entities& target) {
+    if (skillSlot < 0 || skillSlot >= 3 || !skillBar[skillSlot]) {
+        CCLOG("Invalid or empty skill slot: %d", skillSlot);
+        return;
+    }
+
+    auto skill = skillBar[skillSlot];
+    if (skill->isOnCooldown()) {
+        CCLOG("Skill %s is on cooldown.", skill->getName().c_str());
+        return;
+    }
+
+    skill->activate(this, target);
+    skill->resetCooldown();
+}
+
+void Player::updateSkillsCooldown(float deltaTime) {
+    for (const auto& skill : skillBar) {
+        if (skill) {
+            skill->updateCooldown(deltaTime);
+        }
+    }
+}
+
+void Player::updateshieldTime(float deltaTime)
+{
+    if (shieldTime > 0.0f) {
+        shieldTime -= deltaTime;
+        if (shieldTime <= 0.0f || currentShield <= 0.0f) {
+            shieldTime = 0.0f;
+            currentShield = 0.0f;
+            CCLOG("Shield expired.");
+        }
+    }
+}
+
+
+
+void Player::takeDamage(float damage) {
+    if (currentShield > 0.0f) {
+        // 扣除护甲值
+        float absorbed = std::min(damage, currentShield);
+        currentShield -= absorbed;
+        damage -= absorbed;
+        CCLOG("Shield absorbs %.2f damage. Remaining shield: %.2f.", absorbed, currentShield);
+    }
+
+    if (damage > 0.0f) {
+        // 扣除生命值
+        Entities::takeDamage(damage);
+        CCLOG("Player takes %.2f damage. Current health: %.2f.", damage, health);
+    }
+    else {
+        CCLOG("Shield fully absorbed the damage.");
+    }
+}
+
+void Player::heal(float healAmount) {
+    health += healAmount;
+    if (health > maxHealth) 
+        health = maxHealth;
+    CCLOG("Player heals %.2f health. Current health: %.2f", healAmount, health);
+}
+
+void Player::setShield(float shield) {
+    currentShield = shield;
+    CCLOG("Player receives a shield of %.2f.", shield);
+}
+
+float Player::getShield() const {
+    return currentShield;
 }

--- a/genshin/Classes/Common/Entities/Player/Player.h
+++ b/genshin/Classes/Common/Entities/Player/Player.h
@@ -17,6 +17,14 @@ private:
     Armor* armor;             // 护甲
     Accessory* accessory;     // 饰品
 
+    // 技能系统
+    std::vector<std::shared_ptr<Skill>> unlockedSkills; // 已解锁技能
+    std::vector<std::shared_ptr<Skill>> skillBar;       // 技能栏（最多3个技能）
+
+  
+    float currentShield;  // 当前护甲值
+
+
 public:
     Player(float health, Element element);
     Player();  // 默认构造函数
@@ -33,6 +41,10 @@ public:
     // 攻击玩家敌人时根据元素相克
     void attack(Entities& target) override;
 
+    // 玩家受到攻击
+    void takeDamage(float damage) override;
+
+
     // 玩家独特的技能
     void castSkill();
 
@@ -48,6 +60,16 @@ public:
     Weapon* getWeapon() const;
     Armor* getArmor() const;
     Accessory* getAccessory() const;
+
+    // 技能系统
+    void unlockSkill(const std::shared_ptr<Skill>& newSkill);   // 解锁技能
+    bool equipSkill(int skillSlot, const std::shared_ptr<Skill>& skill); // 装备技能
+    void unequipSkill(int skillSlot);                          // 卸载技能
+    void useSkill(int skillSlot, Entities& target);            // 使用技能
+    void updateSkillsCooldown(float deltaTime);                // 更新冷却时间
+
+
+    
 };
 
 #endif // PLAYER_H

--- a/genshin/Classes/Common/Entities/Player/Skill/AttackSkill/AttackSkill.cpp
+++ b/genshin/Classes/Common/Entities/Player/Skill/AttackSkill/AttackSkill.cpp
@@ -1,0 +1,29 @@
+#include "AttackSkill.h"
+#include "cocos2d.h"
+
+AttackSkill::AttackSkill(const std::string& name, float cooldown, float attackPower, float range)
+    : Skill(name, cooldown), attackPower(attackPower), range(range) {}
+
+// 获取攻击力
+float AttackSkill::getAttackPower() const {
+    return attackPower;
+}
+
+// 获取范围
+float AttackSkill::getRange() const {
+    return range;
+}
+
+// 激活技能
+void AttackSkill::activate(Entities* user, Entities& target) {
+    // 检查目标是否在范围内
+    float distance = user->getPosition().distance(target.getPosition());
+    if (distance > range) {
+        CCLOG("AttackSkill: Target out of range for %s.", name.c_str());
+        return;
+    }
+
+    // 对目标造成伤害
+    target.takeDamage(attackPower);
+    CCLOG("%s dealt %.2f damage to target.", name.c_str(), attackPower);
+}

--- a/genshin/Classes/Common/Entities/Player/Skill/AttackSkill/AttackSkill.h
+++ b/genshin/Classes/Common/Entities/Player/Skill/AttackSkill/AttackSkill.h
@@ -1,0 +1,22 @@
+#ifndef ATTACK_SKILL_H
+#define ATTACK_SKILL_H
+
+#include "Skill.h"
+
+class AttackSkill : public Skill {
+private:
+    float attackPower; // 技能攻击力
+    float range;       // 技能范围
+
+public:
+    AttackSkill(const std::string& name, float cooldown, float attackPower, float range);
+
+    // 获取攻击力与范围
+    float getAttackPower() const;
+    float getRange() const;
+
+    // 实现技能激活
+    void activate(Entities* user, Entities& target) override;
+};
+
+#endif // ATTACK_SKILL_H

--- a/genshin/Classes/Common/Entities/Player/Skill/HealSkill/HealSkill.cpp
+++ b/genshin/Classes/Common/Entities/Player/Skill/HealSkill/HealSkill.cpp
@@ -1,0 +1,11 @@
+#include "HealSkill.h"
+#include "cocos2d.h"
+
+HealSkill::HealSkill(const std::string& name, float cooldown, float healAmount)
+    : Skill(name, cooldown), healAmount(healAmount) {}
+
+// 激活治疗技能
+void HealSkill::activate(Entities* user, Entities& target) {
+    user->heal(healAmount);
+    CCLOG("%s healed %.2f health.", name.c_str(), healAmount);
+}

--- a/genshin/Classes/Common/Entities/Player/Skill/HealSkill/HealSkill.h
+++ b/genshin/Classes/Common/Entities/Player/Skill/HealSkill/HealSkill.h
@@ -1,0 +1,17 @@
+#ifndef HEAL_SKILL_H
+#define HEAL_SKILL_H
+
+#include "Skill.h"
+
+class HealSkill : public Skill {
+private:
+    float healAmount; // 恢复的生命值
+
+public:
+    HealSkill(const std::string& name, float cooldown, float healAmount);
+
+    // 激活治疗技能
+    void activate(Entities* user, Entities& target) override;
+};
+
+#endif // HEAL_SKILL_H

--- a/genshin/Classes/Common/Entities/Player/Skill/ShieldSkill/ShieldSkill.cpp
+++ b/genshin/Classes/Common/Entities/Player/Skill/ShieldSkill/ShieldSkill.cpp
@@ -1,0 +1,14 @@
+#include "ShieldSkill.h"
+#include "cocos2d.h"
+
+ShieldSkill::ShieldSkill(const std::string& name, float cooldown, float shieldValue)
+    : Skill(name, cooldown), shieldValue(shieldValue) {}
+
+
+
+// 激活护盾技能
+void ShieldSkill::activate(Entities* user, Entities& target) {
+    user->setShield(shieldValue);
+
+    CCLOG("%s provides %.2f shield .", name.c_str(), shieldValue);
+}

--- a/genshin/Classes/Common/Entities/Player/Skill/ShieldSkill/ShieldSkill.h
+++ b/genshin/Classes/Common/Entities/Player/Skill/ShieldSkill/ShieldSkill.h
@@ -1,0 +1,18 @@
+#ifndef SHIELDSKILL_H
+#define SHIELDSKILL_H
+
+#include "Skill.h"
+
+class ShieldSkill : public Skill {
+private:
+    float shieldValue;   // 初始护甲值
+
+
+public:
+    ShieldSkill(const std::string& name, float cooldown);
+
+    // 激活护甲技能
+    void activate(Entities* user, Entities& target) override;
+};
+
+#endif // SHIELDSKILL_H

--- a/genshin/Classes/Common/Entities/Player/Skill/Skill.cpp
+++ b/genshin/Classes/Common/Entities/Player/Skill/Skill.cpp
@@ -1,0 +1,31 @@
+#include "Skill.h"
+#include "cocos2d.h"
+
+// 构造函数
+Skill::Skill(const std::string& name, float cooldown)
+    : name(name), cooldown(cooldown), currentCooldown(0.0f) {}
+
+// 获取技能名称
+std::string Skill::getName() const {
+    return name;
+}
+
+// 检查技能是否在冷却
+bool Skill::isOnCooldown() const {
+    return currentCooldown > 0.0f;
+}
+
+// 更新冷却时间
+void Skill::updateCooldown(float deltaTime) {
+    if (currentCooldown > 0.0f) {
+        currentCooldown -= deltaTime;
+        if (currentCooldown < 0.0f) {
+            currentCooldown = 0.0f;  // 确保冷却时间不为负数
+        }
+    }
+}
+
+// 重置冷却
+void Skill::resetCooldown() {
+    currentCooldown = cooldown;
+}

--- a/genshin/Classes/Common/Entities/Player/Skill/Skill.h
+++ b/genshin/Classes/Common/Entities/Player/Skill/Skill.h
@@ -1,0 +1,28 @@
+#ifndef SKILL_H
+#define SKILL_H
+
+#include <string>
+#include "../Entities.h"
+
+class Skill {
+protected:
+    std::string name;       // 技能名称
+    float cooldown;         // 技能冷却时间（秒）
+    float currentCooldown;  // 当前剩余冷却时间
+
+public:
+    // 构造函数
+    Skill(const std::string& name, float cooldown);
+    virtual ~Skill() = default;
+
+    // 获取技能名称
+    std::string getName() const;
+
+    bool isOnCooldown() const;       // 检查技能是否在冷却
+    void updateCooldown(float deltaTime);  // 更新冷却时间
+    void resetCooldown();            // 重置冷却
+
+    virtual void activate(Entities* user, Entities& target) = 0;
+};
+
+#endif // SKILL_H


### PR DESCRIPTION
增加了技能类，其中技能包含攻击型，防御性，治疗型技能，防御性技能的逻辑可以增加一个护盾持续时间，可以后续加以改进。在玩家类中设置了技能栏，以及玩家所能学习的全部技能，假设玩家总共只有五个技能，技能栏有三个，方便玩家随时进行替换技能；
改进了元素相克的逻辑，使其适应当前所包含的元素类型。